### PR TITLE
feat(BE-40) added functionalities for a lawyer to send email to users

### DIFF
--- a/src/Controllers/LawyerController.cs
+++ b/src/Controllers/LawyerController.cs
@@ -106,14 +106,16 @@ namespace src.Controllers
         }
 
 
-        [SwaggerOperation(Summary = "Send email to the reviewer")]
+        [SwaggerOperation(Summary = "Sends email to the user from reviewer")]
         [HttpPost("email/create")]
         [Authorize(Roles = "Lawyer", AuthenticationSchemes = "Bearer")]
-        public ActionResult SendEmail(EmailData emailData)
+        public ActionResult SendEmail(EmailDataDto emailData)
         {
+            const string EMAIL_SUBJECT = "Plea for removal of review";
+
             try
             {
-                _emailSender.SendEmailWrapper(emailData);
+                _emailSender.SendEmailAsync(emailData.EmailToId, EMAIL_SUBJECT, emailData.EmailBody);
                 return Ok();
             }
             catch(SmtpCommandException ex)

--- a/src/CustomValidations/EmailBodyValidator.cs
+++ b/src/CustomValidations/EmailBodyValidator.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.IdentityModel.Tokens;
+using src.Models;
+using src.Models.Dtos;
+using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+
+namespace src.CustomValidations
+{
+    public class EmailBodyValidator : ValidationAttribute
+    {
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+        {
+            var emailData = (EmailDataDto)validationContext.ObjectInstance;
+            return isEmailBodyValid(emailData.EmailBody) ? ValidationResult.Success : new ValidationResult("Body formatting seems wrong, please check your text for errors in formatting");
+        }
+
+        public static bool isEmailBodyValid(string body)
+        {
+            var regex = "<(\"[^\"]*\"|'[^']*'|[^'\">])*>";
+
+            if (body.IsNullOrEmpty())
+            {
+                return false;
+            }
+            if(Regex.IsMatch(body, regex) || body.Length > 0)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+
+        }
+    }
+}

--- a/src/CustomValidations/EmailValidators.cs
+++ b/src/CustomValidations/EmailValidators.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.IdentityModel.Tokens;
+using src.Models;
+using System.Net.Mail;
+using src.Models.Dtos;
+using System.Text.RegularExpressions;
+
+namespace src.CustomValidations
+{
+    public class EmailValidator: ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
+        {
+
+            var emailData = (EmailDataDto)validationContext.ObjectInstance;
+            if (emailData.EmailToId.IsNullOrEmpty() || !isEmailValid(emailData.EmailToId))
+            {
+                return new ValidationResult("Invalid email format");
+            }
+            return ValidationResult.Success;
+        }
+
+        public static bool isEmailValid(string email) {
+
+            string regex = @"^[^@\s]+@[^@\s]+\.(com|net|org|gov)$";
+            return Regex.IsMatch(email, regex);
+        }
+    }
+}

--- a/src/Models/Dtos/EmailDataDto.cs
+++ b/src/Models/Dtos/EmailDataDto.cs
@@ -1,0 +1,14 @@
+﻿using src.CustomValidations;
+using System.ComponentModel.DataAnnotations;
+
+namespace src.Models.Dtos
+{
+    public class EmailDataDto
+    {
+        [EmailValidator]
+        public string EmailToId { get; set; }
+
+        [EmailBodyValidator]
+        public string EmailBody { get; set; }
+    }
+}

--- a/src/Models/EmailData.cs
+++ b/src/Models/EmailData.cs
@@ -1,9 +1,13 @@
-﻿namespace src.Models
+﻿using System.ComponentModel.DataAnnotations;
+using src.CustomValidations;
+namespace src.Models
 {
     public class EmailData
     {
+        [EmailValidator]
         public string EmailToId { get; set; }
         public string EmailSubject { get; set; }
+        [EmailBodyValidator]
         public string EmailBody { get; set; }
     }
 }

--- a/src/Models/MailKitEmailSenderOptions.cs
+++ b/src/Models/MailKitEmailSenderOptions.cs
@@ -1,6 +1,7 @@
 ﻿
 
 using MailKit.Security;
+using src.CustomValidations;
 namespace src.Models
 {
     public class MailKitEmailSenderOptions
@@ -15,6 +16,7 @@ namespace src.Models
 
         public SecureSocketOptions Host_SecureSocketOptions = SecureSocketOptions.Auto;
 
+        [EmailValidator]
         public string Sender_Email { get; set; }
 
         public string Sender_Name { get; set; }


### PR DESCRIPTION
Aim of PR
Added functionality that allows the lawyer to send email to a user, regarding taking down a review

Achieved through:
1.Custom Server Validators for EmailAddress and EmailBody
2. Email sending capability implementation in the Lawyer Controller
3. EmailDataDto class for Logic Abstraction

Ticket Link: [https://linear.app/team-socket/issue/BAC-40/functionality-for-the-lawyer-to-send-email-to-the-user](url)
Ticket No: BAC-40