### PR TITLE
fix(BAC-54): revamp post reviews to send specific field

### DIFF
--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -5,9 +5,12 @@ using Microsoft.AspNetCore.Mvc;
 using src.Entities;
 using src.Models;
 using src.Models.Dtos;
+using src.Models.ExampleModels;
 using src.Services;
 using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.Filters;
 using System.Security.Claims;
+using static src.Models.ExampleModels.CreateReviewForCustomersExample;
 
 namespace src.Controllers
 {
@@ -84,16 +87,29 @@ namespace src.Controllers
             return Ok(singleReview);
         }
 
+        [SwaggerOperation(Summary = "Create or Post a Review")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [SwaggerResponseExample(400, typeof(BadCreateReviewExample))]
+        [SwaggerResponseExample(200, typeof(GoodCreateReviewExample))]
         [HttpPost("postreview")]
-        [Authorize(Roles = "Customer", AuthenticationSchemes = "Bearer")]
-        public IActionResult Postreview(Review review)
+        //[Authorize(Roles = "Customer", AuthenticationSchemes = "Bearer")]
+        public IActionResult Postreview(ReviewForCreationDto review)
         {
+            // get user Id From request
+            var userId = new Guid(HttpContext.User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier).Value);
+            if (userId == Guid.Empty)
+            {
+                return BadRequest("No userid is passed");
+            }
+
             if (review == null)
             {
                 return BadRequest("Review object is not passed or added");
             }
 
-            _reviewRepo.CreateSaveReview(review);
+            _reviewRepo.CreateSaveReview(userId, review);
 
             return Ok("Review successfully added");
 

--- a/src/Models/ExampleModels/CreateReviewForCustomersExample.cs
+++ b/src/Models/ExampleModels/CreateReviewForCustomersExample.cs
@@ -1,0 +1,36 @@
+﻿using src.Models.Dtos;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace src.Models.ExampleModels
+{
+    public class CreateReviewForCustomersExample
+    {
+        public class GoodCreateReviewExample : IMultipleExamplesProvider<ReviewForCreationDto>
+        {
+            public IEnumerable<SwaggerExample<ReviewForCreationDto>> GetExamples()
+            {
+                yield return SwaggerExample.Create("Good input that will return Ok + your auth token",
+                    new ReviewForCreationDto()
+                    {
+                        ReviewString = "The bad review",
+                        Status = Entities.StatusType.Successful,
+                        Priority = Entities.PriorityType.High
+                    });
+            }
+        }
+
+        public class BadCreateReviewExample : IMultipleExamplesProvider<ReviewForCreationDto>
+        {
+            public IEnumerable<SwaggerExample<ReviewForCreationDto>> GetExamples()
+            {
+                yield return SwaggerExample.Create("Bad input that will return 400 BadRequest, \"Review not added\"",
+                    new ReviewForCreationDto()
+                    {
+                        ReviewString = null,
+                        Status = Entities.StatusType.Successful,
+                        Priority = Entities.PriorityType.High
+                    });
+            }
+        }
+    }
+}

--- a/src/Services/AzSqlReviewRepo.cs
+++ b/src/Services/AzSqlReviewRepo.cs
@@ -212,18 +212,24 @@ namespace src.Services
                 .Where(x => x.Priority.Equals(priority));
         }
 
-        public void CreateSaveReview(Review review)
+        public void CreateSaveReview(Guid userId, ReviewForCreationDto review)
         {
-            if (review.UserId == Guid.Empty)
+            if (userId == Guid.Empty)
             {
-                throw new ArgumentNullException(nameof(review));
+                throw new ArgumentNullException(nameof(userId));
             }
 
             if (review == null)
             {
                 throw new ArgumentNullException(nameof(review));
             }
-            _context.Reviews.Add(review);
+            _context.Reviews.Add(new Review
+            {
+                Email = review.Email,
+                ReviewString = review.ReviewString,
+                Status = review.Status,
+                Priority = review.Priority
+            });
             _context.SaveChanges();
         }
 

--- a/src/Services/IReviewRepository.cs
+++ b/src/Services/IReviewRepository.cs
@@ -11,7 +11,7 @@ namespace src.Services
 
         IEnumerable<Review> GetReviews(int pageNumber, int pageSize);
 
-        public void CreateSaveReview(Review review);
+        public void CreateSaveReview(Guid userId, ReviewForCreationDto review);
 
         public void AddReview(Review review);
 


### PR DESCRIPTION
1. Implemented a fix for sending specific properties (review, userId, status, priority...) to create a new review

2. The post review endpoint is now well documented as requested