### PR TITLE
Feat/be 59 allow lawyer to send email to the bad review

### DIFF
--- a/src/Controllers/LawyerController.cs
+++ b/src/Controllers/LawyerController.cs
@@ -9,8 +9,10 @@ using src.Entities;
 using src.Helpers;
 using src.Models;
 using src.Models.Dtos;
+using src.Models.ExampleModels;
 using src.Services;
 using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.Filters;
 using System.Text.Json;
 
 namespace src.Controllers
@@ -111,14 +113,15 @@ namespace src.Controllers
         [SwaggerOperation(Summary = "Sends email to the user from reviewer")]
         [HttpPost("email/create")]
         [Authorize(Roles = "Lawyer", AuthenticationSchemes = "Bearer")]
-        public ActionResult SendEmail(EmailDataDto emailData)
+        [SwaggerResponseExample(400, typeof(BadSendingEmailTExample))]
+        [SwaggerResponseExample(200, typeof(GoodSendingEmailTExample))]
+        public ActionResult SendEmail([FromBody]EmailDataDto emailData)
         {
             const string EMAIL_SUBJECT = "Plea for removal of review";
-
             try
             {
                 _emailSender.SendEmailAsync(emailData.EmailToId, EMAIL_SUBJECT, emailData.EmailBody);
-                return Ok();
+                return Ok("Success");
             }
             catch(SmtpCommandException ex)
             {

--- a/src/Models/Dtos/EmailDataDto.cs
+++ b/src/Models/Dtos/EmailDataDto.cs
@@ -5,9 +5,11 @@ namespace src.Models.Dtos
 {
     public class EmailDataDto
     {
+        [Required]
         [EmailValidator]
         public string EmailToId { get; set; }
 
+        [Required]
         [EmailBodyValidator]
         public string EmailBody { get; set; }
     }

--- a/src/Models/ExampleModels/SendingEmailTExample.cs
+++ b/src/Models/ExampleModels/SendingEmailTExample.cs
@@ -1,0 +1,31 @@
+﻿using src.Models.Dtos;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace src.Models.ExampleModels
+{
+    public class GoodSendingEmailTExample: IMultipleExamplesProvider<EmailDataDto>
+    {
+        public IEnumerable<SwaggerExample<EmailDataDto>> GetExamples()
+        {
+            yield return SwaggerExample.Create("Parameters with example used for sending email (Response -> Success)",
+                new EmailDataDto()
+                {
+                    EmailToId = "useremail@gmail.com",
+                    EmailBody = "Content of the meassge goes here"
+                });
+        }
+    }
+
+    public class BadSendingEmailTExample : IMultipleExamplesProvider<EmailDataDto>
+    {
+        public IEnumerable<SwaggerExample<EmailDataDto>> GetExamples()
+        {
+            yield return SwaggerExample.Create("Parameters with example used for sending email (Response -> Success)",
+                new EmailDataDto()
+                {
+                    EmailToId = "useremail@gmail.com",
+                    EmailBody = "Content of the meassge goes here"
+                });
+        }
+    }
+}


### PR DESCRIPTION
Aim of PR
1. Enables sending of email from the lawyer to the user in regards to bad review
2. Updated Example use case format for email sending

Ticket No : BAC-59
Ticket Link: [https://linear.app/team-repute/issue/BAC-59/allow-lawyer-to-send-email-to-the-bad-review](url)