### PR TITLE
feat(BAC-65): upload multiple reviews from csv

### DIFF
--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -235,5 +235,17 @@ namespace src.Controllers
             }
             return BadRequest("Invalid language string, please select one of {\"english\", \"german\", \"russian\", \"chinese\"}");
         }
+
+        [SwaggerOperation(Summary = "Create multiple reviews")]
+        [HttpPost]
+        [Route("UploadReviewsCSV")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public IActionResult UploadReviewsCSV(IFormFile file)
+        {
+            var data = _reviewRepo.ReviewsBulkUpload(file);
+
+            return Ok("Reviews bulk upload added successfully");
+        }
+
     }
 }

--- a/src/Models/Dtos/ReviewCsvDto.cs
+++ b/src/Models/Dtos/ReviewCsvDto.cs
@@ -1,0 +1,14 @@
+﻿using src.Entities;
+using System.ComponentModel.DataAnnotations;
+
+namespace src.Models.Dtos
+{
+    public class ReviewCsvDto
+    {
+        public string Email { get; set; }
+        public string ReviewString { get; set; }
+        public string CustomerEmail { get; set; }
+        public string Status { get; set; }
+        public string Priority { get; set; }
+    }
+}

--- a/src/Services/AzSqlReviewRepo.cs
+++ b/src/Services/AzSqlReviewRepo.cs
@@ -1,10 +1,13 @@
 using AutoMapper;
+using CsvHelper;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using src.Data;
 using src.Entities;
 using src.Models.Dtos;
 using System.Collections;
+using System.Formats.Asn1;
 
 namespace src.Services
 {
@@ -12,17 +15,20 @@ namespace src.Services
     {
         public readonly ApplicationDbContext _context;
         private readonly IMapper _mapper;
+        private readonly UserManager<ApplicationUser> _userManager;
+
 
 
         public IQueryable<Review> Reviews => throw new NotImplementedException();
 
-        public AzSqlReviewRepo(ApplicationDbContext context, IMapper mapper)
+        public AzSqlReviewRepo(ApplicationDbContext context, IMapper mapper, UserManager<ApplicationUser> userManager)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _mapper = mapper;
+            _userManager = userManager;
         }
 
-       
+
         public void AddReview(Review review)
         {            
             if (review.UserId == Guid.Empty)
@@ -278,6 +284,43 @@ namespace src.Services
             Save();
 
             return model;
+        }
+
+        public async Task<dynamic> ReviewsBulkUpload(IFormFile file)
+        {
+
+            if (file == null)
+            {
+                throw new ArgumentNullException(nameof(file));
+            }
+
+            using var memoryStream = new MemoryStream(new byte[file.Length]);
+            file.CopyTo(memoryStream);
+            memoryStream.Position = 0;
+
+            using (var reader = new StreamReader(memoryStream))
+            using (var csvReader = new CsvReader(reader, System.Globalization.CultureInfo.InvariantCulture))
+            {
+                var csvRecords = csvReader.GetRecords<ReviewCsvDto>().ToList();
+
+                foreach (var item in csvRecords)
+                {
+                    var user = _userManager.FindByEmailAsync(item.CustomerEmail).GetAwaiter().GetResult();
+                    var userId = Guid.Parse(user.Id);
+
+                    _context.Reviews.Add(new Review
+                    {
+                        Email = item.Email,
+                        ReviewString = item.ReviewString,
+                        Priority = Enum.Parse<PriorityType>(item.Priority),
+                        Status = Enum.Parse<StatusType>(item.Status),
+                        TimeStamp = DateTime.Now,
+                        UserId = userId
+                    });
+                }
+                _context.SaveChanges();
+                return "Success";
+            }
         }
     }
 }

--- a/src/Services/IReviewRepository.cs
+++ b/src/Services/IReviewRepository.cs
@@ -42,5 +42,8 @@ namespace src.Services
 
         Task<ChallengeReview> PostChallengeReview (ChallengeUserReviewDto challenge);
 
+        public Task<dynamic> ReviewsBulkUpload(IFormFile file);
+
+
     }
 }

--- a/src/src.csproj
+++ b/src/src.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="MailKit" Version="3.4.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.11" />
 


### PR DESCRIPTION
Ticket Number: BAC-65

Linear URL: https://linear.app/team-repute/issue/BAC-65/send-more-than-one-review-at-a-time-post-apireviews

This feature allows multiple reviews to be added.
1. The review data are imported into this endpoint when consumed and adds the records to the database
2. It uses the CsvHelper nuget package to import a csv file data.

Slack name: dProcessor